### PR TITLE
Add options to Briefly.create

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,16 @@
+Copyright (c) 2015 CargoSense, Inc.
+
+Portions derived from Plug, https://github.com/elixir-lang/plug
+Copyright (c) 2013 Plataformatec
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.

--- a/README.md
+++ b/README.md
@@ -65,12 +65,4 @@ config (and pass `prefix` and `extname` to `Briefly.create` to override
 
 ## License
 
-The MIT License (MIT)
-
-Copyright (c) 2015 CargoSense, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+See [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add as a dependency to your `mix.exs`:
 ```elixir
 def deps do
   [
-    briefly: "~> 0.1"
+    briefly: "~> 0.2"
   ]
 end
 ```
@@ -34,11 +34,14 @@ end
 ## Example
 
 ```elixir
-{:ok, path} = Briefly.create("myprefix")
+{:ok, path} = Briefly.create
 File.write!(path, "Some Text")
 content = File.read!(path)
 # When this process exits, the file at `path` is removed
 ```
+
+See [the documentation](http://hexdocs.pm/briefly/Briefly.html#create/1) to see
+the options that available to `Briefly.create/1` and `Briefly.create!/1`.
 
 ## Configuration
 
@@ -47,14 +50,18 @@ following Mix config:
 
 ```elixir
 config :briefly,
-  directory: [{:system, "TMPDIR"}, {:system, "TMP"}, {:system, "TEMP"}, "/tmp"]
+  directory: [{:system, "TMPDIR"}, {:system, "TMP"}, {:system, "TEMP"}, "/tmp"],
+  default_prefix: "briefly",
+  default_extname: ""
   ```
 
 `directory` here declares an ordered list of possible directory definitions that Briefly will check in order.
 
 The `{:system, env_var}` tuples point to system environment variables to be checked. If none of these are defined, Briefly will use the final entry: `/tmp`.
 
-You can override the `directory` setting with your own candidates in your application Mix config.
+You can override the settings with your own candidates in your application Mix
+config (and pass `prefix` and `extname` to `Briefly.create` to override
+`default_prefix` and `default_extname` on a case-by-case basis).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Simple, robust temporary file support for Elixir.
 
 ## Highlighted Features
 
-* Create temporary files using a prefix
+* Create temporary files with prefix and extname options
 * Files are removed after the process that requested the file dies
 * File creation is based on [Plug.Upload](http://hexdocs.pm/plug/Plug.Upload.html)'s robust retry logic
-* Configurable temporary directory setting with support for fallbacks
+* Configurable; built-in support for system environment variables and fallbacks
 
 ## Installation
 

--- a/lib/briefly.ex
+++ b/lib/briefly.ex
@@ -8,30 +8,35 @@ defmodule Briefly do
     Briefly.Supervisor.start_link()
   end
 
+  @type create_opts :: [
+    {:prefix, binary},
+    {:extname, binary}
+  ]
+
   @doc """
-  Requests a temporary file to be created with the given prefix
+  Requests a temporary file to be created with the given options
   """
-  @spec create(binary) ::
-  {:ok, binary} |
-  {:too_many_attempts, binary, pos_integer} |
-  {:no_tmp, [binary]}
-  def create(prefix) do
-    GenServer.call(Briefly.File.server, {:file, prefix})
+  @spec create(create_opts) ::
+    {:ok, binary} |
+    {:too_many_attempts, binary, pos_integer} |
+    {:no_tmp, [binary]}
+  def create(opts \\ []) do
+    GenServer.call(Briefly.File.server, {:file, opts})
   end
 
   @doc """
-  Requests a temporary file to be created with the given prefix
+  Requests a temporary file to be created with the given options
   and raises on failure
   """
-  @spec create!(binary) :: binary | no_return
-  def create!(prefix) do
-    case create(prefix) do
+  @spec create!(create_opts) :: binary | no_return
+  def create!(opts \\ []) do
+    case create(opts) do
       {:ok, path} ->
         path
       {:too_many_attempts, tmp, attempts} ->
         raise "tried #{attempts} times to create a temporary file at #{tmp} but failed. What gives?"
       {:no_tmp, _tmps} ->
-        raise "could not create a tmp directory to store temporary files. Set TMPDIR, TMP, or TEMP to a directory with write permission"
+        raise "could not create a tmp directory to store temporary files. Set the :briefly :directory application setting to a directory with write permission"
     end
   end
 

--- a/lib/briefly/config.ex
+++ b/lib/briefly/config.ex
@@ -1,20 +1,22 @@
 defmodule Briefly.Config do
   @moduledoc false
 
-  @default_directory [{:system, "TMPDIR"}, {:system, "TMP"}, {:system, "TEMP"}, "/tmp"]
-
   def directory do
     get(:directory)
-    |> List.wrap
-    |> Enum.find_value(&runtime_value/1)
+  end
+
+  def default_prefix do
+    get(:default_prefix)
+  end
+
+  def default_extname do
+    get(:default_extname)
   end
 
   defp get(key) do
-    Application.get_env(:briefly, key, Keyword.get(defaults, key))
-  end
-
-  defp defaults do
-    [{:directory, @default_directory}]
+    Application.get_env(:briefly, key, [])
+    |> List.wrap
+    |> Enum.find_value(&runtime_value/1)
   end
 
   defp runtime_value({:system, env_key}) do

--- a/lib/briefly/config.ex
+++ b/lib/briefly/config.ex
@@ -1,17 +1,11 @@
 defmodule Briefly.Config do
   @moduledoc false
 
-  def directory do
-    get(:directory)
-  end
+  def directory, do: get(:directory)
 
-  def default_prefix do
-    get(:default_prefix)
-  end
+  def default_prefix, do: get(:default_prefix)
 
-  def default_extname do
-    get(:default_extname)
-  end
+  def default_extname, do: get(:default_extname)
 
   defp get(key) do
     Application.get_env(:briefly, key, [])

--- a/lib/briefly/file.ex
+++ b/lib/briefly/file.ex
@@ -32,10 +32,6 @@ defmodule Briefly.File do
     end
   end
 
-  def handle_call(msg, from, state) do
-    super(msg, from, state)
-  end
-
   def handle_info({:DOWN, _ref, :process, pid, _reason}, {_, ets} = state) do
     case :ets.lookup(ets, pid) do
       [{pid, _tmp, paths}] ->

--- a/lib/briefly/file.ex
+++ b/lib/briefly/file.ex
@@ -23,10 +23,10 @@ defmodule Briefly.File do
     {:ok, {[tmp, cwd], ets}}
   end
 
-  def handle_call({:file, prefix}, {pid, _ref}, {tmps, ets} = state) do
+  def handle_call({:file, opts}, {pid, _ref}, {tmps, ets} = state) do
     case find_tmp_dir(pid, tmps, ets) do
       {:ok, tmp, paths} ->
-        {:reply, open(prefix, tmp, 0, pid, ets, paths), state}
+        {:reply, open(opts, tmp, 0, pid, ets, paths), state}
       {:no_tmp, _} = error ->
         {:reply, error, state}
     end
@@ -81,15 +81,15 @@ defmodule Briefly.File do
     end
   end
 
-  defp open(prefix, tmp, attempts, pid, ets, paths) when attempts < @max_attempts do
-    path = path(prefix, tmp)
+  defp open(opts, tmp, attempts, pid, ets, paths) when attempts < @max_attempts do
+    path = path(opts, tmp)
 
     case :file.write_file(path, "", [:write, :raw, :exclusive, :binary]) do
       :ok ->
         :ets.update_element(ets, pid, {3, [path|paths]})
         {:ok, path}
       {:error, reason} when reason in [:eexist, :eaccess] ->
-        open(prefix, tmp, attempts + 1, pid, ets, paths)
+        open(opts, tmp, attempts + 1, pid, ets, paths)
     end
   end
 
@@ -100,10 +100,20 @@ defmodule Briefly.File do
   @compile {:inline, i: 1}
   defp i(integer), do: Integer.to_string(integer)
 
-  defp path(prefix, tmp) do
+  defp path(opts, tmp) do
     {_mega, sec, micro} = :os.timestamp
+    options = opts |> Enum.into(%{})
     scheduler_id = :erlang.system_info(:scheduler_id)
-    tmp <> "/" <> prefix <> "-" <> i(sec) <> "-" <> i(micro) <> "-" <> i(scheduler_id)
+    IO.iodata_to_binary([tmp, "/",
+                         prefix(options),
+                         "-", i(sec), "-", i(micro), "-", i(scheduler_id),
+                         extname(options)])
   end
+
+  defp prefix(%{prefix: value}), do: value
+  defp prefix(_), do: Briefly.Config.default_prefix
+
+  defp extname(%{extname: value}), do: value
+  defp extname(_), do: Briefly.Config.default_extname
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Briefly.Mixfile do
 
   def project do
     [app: :briefly,
-     version: "0.1.1",
+     version: "0.2.0",
      elixir: "~> 1.0",
      source_url: "https://github.com/CargoSense/briefly",
      build_embedded: Mix.env == :prod,
@@ -17,7 +17,8 @@ defmodule Briefly.Mixfile do
   # Type `mix help compile.app` for more information
   def application do
     [applications: [:logger],
-     mod: {Briefly, []}]
+     mod: {Briefly, []},
+     env: default_env]
   end
 
   # Dependencies can be Hex packages:
@@ -34,12 +35,18 @@ defmodule Briefly.Mixfile do
      {:ex_doc, "~> 0.8", only: :dev}]
   end
 
-  def package do
+  defp package do
     [description: "Temporary file support",
      files: ["lib", "config", "mix.exs", "README*"],
      contributors: ["Bruce Williams"],
      licenses: ["MIT"],
      links: %{github: "https://github.com/CargoSense/briefly"}]
+  end
+
+  defp default_env do
+    [directory: [{:system, "TMPDIR"}, {:system, "TMP"}, {:system, "TEMP"}, "/tmp"],
+     default_prefix: "briefly",
+     default_extname: ""]
   end
 
 end

--- a/test/lib/briefly_test.exs
+++ b/test/lib/briefly_test.exs
@@ -3,12 +3,13 @@ defmodule Test.Briefly do
 
   @prefix "temp"
   @fixture "content"
+  @extname ".tst"
 
   test "removes the random file on process death" do
     parent = self()
 
     {pid, ref} = spawn_monitor fn ->
-      {:ok, path} = Briefly.create(@prefix)
+      {:ok, path} = Briefly.create
       send parent, {:path, path}
       File.write!(path, @fixture)
       assert File.read!(path) == @fixture
@@ -23,8 +24,23 @@ defmodule Test.Briefly do
 
     receive do
       {:DOWN, ^ref, :process, ^pid, :normal} ->
-        {:ok, _} = Briefly.create(@prefix)
+        {:ok, _} = Briefly.create
         refute File.exists?(path)
     end
   end
+
+  test "uses the prefix" do
+    {_pid, _ref} = spawn_monitor fn ->
+      {:ok, path} = Briefly.create(prefix: @prefix)
+      assert Path.basename(path) |> String.starts_with?(@prefix <> "-")
+    end
+  end
+
+  test "uses the extname" do
+    {_pid, _ref} = spawn_monitor fn ->
+      {:ok, path} = Briefly.create(extname: @extname)
+      assert Path.extname(path) == @extname
+    end
+  end
+
 end


### PR DESCRIPTION
This adds `:prefix` and `:extname` options for temporary file creation.
