### PR TITLE
Quiet a couple of Elixir 1.4 warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,8 +8,8 @@ defmodule Briefly.Mixfile do
      source_url: "https://github.com/CargoSense/briefly",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     package: package,
-     deps: deps]
+     package: package(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application
@@ -18,7 +18,7 @@ defmodule Briefly.Mixfile do
   def application do
     [applications: [:logger],
      mod: {Briefly, []},
-     env: default_env]
+     env: default_env()]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
There are three places where `mix.exs` makes zero-arity function calls without parentheses; Elixir 1.4 now issues warnings when it sees this:

```
warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:11

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:12

warning: variable "default_env" does not exist and is being expanded to "default_env()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:21
```

This PR adds the parens, which makes the warnings go away.
