### PR TITLE
Add Briefly.cleanup

### DIFF
--- a/lib/briefly.ex
+++ b/lib/briefly.ex
@@ -41,4 +41,12 @@ defmodule Briefly do
     end
   end
 
+  @doc """
+  Removes the temporary files and directories created by the current process and
+  return their paths.
+  """
+  @spec cleanup :: [binary]
+  def cleanup do
+    GenServer.call(Briefly.Entry.server, :cleanup)
+  end
 end


### PR DESCRIPTION
It is sometimes useful to cleanup temporary files created in the context
of the current process without waiting for it to shutdown.

For example, one may have a long-lived worker process that needs to
regularly remove all files created via Briefly to avoid using all disk
space over time.

Although this could be achieved by keeping track of those files in the
worker process directly, it is done much more cleanly by leveraging the
already existing Briefly ETS table.

The function returns the list of paths tracked by Briefly for the
current process in case the client wants to perform further processing.