### PR TITLE
Avoid folder naming conflicts with monotonic time and random padding

### DIFF
--- a/lib/briefly/entry.ex
+++ b/lib/briefly/entry.ex
@@ -113,21 +113,26 @@ defmodule Briefly.Entry do
   defp i(integer), do: Integer.to_string(integer)
 
   defp path(options, tmp) do
-    {_mega, sec, micro} = :os.timestamp()
-    scheduler_id = :erlang.system_info(:scheduler_id)
+    time = :erlang.monotonic_time() |> to_string |> String.trim("-")
 
-    IO.iodata_to_binary([
-      tmp,
-      "/",
-      prefix(options),
-      "-",
-      i(sec),
-      "-",
-      i(micro),
-      "-",
-      i(scheduler_id),
-      extname(options)
-    ])
+    folder =
+      Enum.join(
+        [
+          prefix(options),
+          time,
+          random_padding()
+        ],
+        "-"
+      ) <> extname(options)
+
+    Path.join([tmp, folder])
+  end
+
+  defp random_padding(length \\ 20) do
+    :crypto.strong_rand_bytes(length)
+    |> Base.url_encode64()
+    |> binary_part(0, length)
+    |> String.replace(~r/[[:punct:]]/, "")
   end
 
   defp prefix(%{prefix: value}), do: value


### PR DESCRIPTION
👋. Briefly looks like a nice library to use for tempfiles in Elixir!

I wanted to ensure a better promise of not having conflicting folder names (per #16) and I think it's a common user experience to expect that the auto-generated folders will be unique.

To accomplish that end, I switched to using monotonic time (so each erlang vm will be unique in itself) and added cryptographically generated padding.

The switch to using monotonic time and random padding from crypto
to ensure that folders are created uniquely even if created in same moment
by different users or different instances of server.

By adding 20 chars of random padding along with monotonic time, the chance of
collisions is so small as to be negligible.

Further work could add a safety check that it retries folder creation if first one
fails.

Fixes: https://github.com/CargoSense/briefly/issues/16.

If this sounds good, I'm happy to contribute it to the main repo for Briefly 🎉 😸.