### PR TITLE
Add monitor_pid option to Briefly.create/1

### DIFF
--- a/lib/briefly.ex
+++ b/lib/briefly.ex
@@ -11,7 +11,8 @@ defmodule Briefly do
   @type create_opts :: [
           {:prefix, binary},
           {:extname, binary},
-          {:directory, boolean}
+          {:directory, boolean},
+          {:monitor_pid, pid()}
         ]
 
   @doc """
@@ -47,8 +48,9 @@ defmodule Briefly do
   Removes the temporary files and directories created by the current process and
   return their paths.
   """
-  @spec cleanup :: [binary]
-  def cleanup do
-    GenServer.call(Briefly.Entry.server(), :cleanup)
+  @spec cleanup(pid() | nil) :: [binary]
+  def cleanup, do: cleanup(self())
+  def cleanup(monitor_pid) do
+    GenServer.call(Briefly.Entry.server(), {:cleanup, monitor_pid})
   end
 end


### PR DESCRIPTION
When you need to keep temp file after the current process died.

For example, if you try to send a briefly file via `Plug.Conn.send_file/5` in a request process, it could fail because the actual `:cowboy_http:sendfile` call happens in the parent connection process.

It means that the request process die before the connection process sent the file, leading to an error.

----

I have a similar issue with `Exfile.Tempfile` module that has similar implementation: https://github.com/keichan34/exfile/issues/64

Also I've created an example app to demonstrate the issue with cowboy: https://github.com/scarfacedeb/exfile_sendfile_example

----

Fixes: #14