### PR TITLE
Fix supervisor warning for Elixir 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: elixir
-elixir: 1.7
+elixir:
+  - 1.7
+  - 1.8
+  - 1.9
+  - 1.10
 notifications:
   recipients:
     - bruce.williams@cargosense.com
+    - devstopfix@gmail.com
 otp_release:
   - 19.3
   - 20.3
   - 21.0
+  - 22.0

--- a/README.md
+++ b/README.md
@@ -18,9 +18,20 @@ Add as a dependency to your `mix.exs`:
 ```elixir
 def deps do
   [
-    briefly: "~> 0.4"
+    briefly: "~> 0.3"
   ]
 end
+```
+
+or grab the latest with:
+
+```elixir
+{
+  :briefly,
+  git: "https://github.com/CargoSense/briefly",
+  ref: "2526e9674a4e6996137e066a1295ea60962712b8"
+  # "~> 0.4" https://github.com/CargoSense/briefly/issues/17
+}
 ```
 
 Install it with `mix deps.get`.

--- a/lib/briefly/entry.ex
+++ b/lib/briefly/entry.ex
@@ -8,15 +8,15 @@ defmodule Briefly.Entry do
 
   use GenServer
 
-  def start_link() do
-    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  def start_link(init_arg) do
+    GenServer.start_link(__MODULE__, init_arg, name: __MODULE__)
   end
 
   ## Callbacks
 
   @max_attempts 10
 
-  def init(:ok) do
+  def init(_init_arg) do
     tmp = Briefly.Config.directory()
     cwd = Path.join(File.cwd!(), "tmp")
     ets = :ets.new(:briefly, [:private])

--- a/lib/briefly/supervisor.ex
+++ b/lib/briefly/supervisor.ex
@@ -6,12 +6,10 @@ defmodule Briefly.Supervisor do
   end
 
   def init(:ok) do
-    import Supervisor.Spec
-
     children = [
-      worker(Briefly.Entry, [])
+      Briefly.Entry
     ]
 
-    supervise(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 end


### PR DESCRIPTION
warning: Supervisor.Spec.supervise/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/briefly/supervisor.ex:Briefly.Supervisor.init/1