### PR TITLE
Use Path.join() to join tmp directory and briefly-nnnnnn subdirectory

### DIFF
--- a/lib/briefly/entry.ex
+++ b/lib/briefly/entry.ex
@@ -68,7 +68,7 @@ defmodule Briefly.Entry do
 
   defp ensure_tmp_dir(tmps) do
     {mega, _, _} = :os.timestamp()
-    subdir = "briefly-" <> i(mega)
+    subdir = "briefly-#{mega}"
     Enum.find_value(tmps, &write_tmp_dir(Path.join(&1, subdir)))
   end
 
@@ -109,9 +109,6 @@ defmodule Briefly.Entry do
   defp open(_prefix, tmp, attempts, _pid, _ets, _paths) do
     {:too_many_attempts, tmp, attempts}
   end
-
-  @compile {:inline, i: 1}
-  defp i(integer), do: Integer.to_string(integer)
 
   defp path(options, tmp) do
     time = :erlang.monotonic_time() |> to_string |> String.trim("-")

--- a/lib/briefly/entry.ex
+++ b/lib/briefly/entry.ex
@@ -69,7 +69,7 @@ defmodule Briefly.Entry do
   defp ensure_tmp_dir(tmps) do
     {mega, _, _} = :os.timestamp()
     subdir = "briefly-" <> i(mega)
-    Enum.find_value(tmps, &write_tmp_dir(&1 <> subdir))
+    Enum.find_value(tmps, &write_tmp_dir(Path.join(&1, subdir)))
   end
 
   defp write_tmp_dir(path) do


### PR DESCRIPTION
Without Path.join(), Briefly tries to create files like /tmpbriefly-123, missing a / in the path