### PR TITLE
add: config sub_directory_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ following Mix config:
 ```elixir
 config :briefly,
   directory: [{:system, "TMPDIR"}, {:system, "TMP"}, {:system, "TEMP"}, "/tmp"],
+  sub_directory_prefix: "briefly",
   default_prefix: "briefly",
   default_extname: ""
   ```

--- a/lib/briefly/config.ex
+++ b/lib/briefly/config.ex
@@ -3,6 +3,8 @@ defmodule Briefly.Config do
 
   def directory, do: get(:directory)
 
+  def sub_directory_prefix, do: get(:sub_directory_prefix)
+
   def default_prefix, do: get(:default_prefix)
 
   def default_extname, do: get(:default_extname)

--- a/lib/briefly/entry.ex
+++ b/lib/briefly/entry.ex
@@ -70,8 +70,8 @@ defmodule Briefly.Entry do
   defp ensure_tmp_dir(tmps) do
     {mega, _, _} = :os.timestamp()
     [_tmp, _cwd, sub] = tmps
-    subdir = sub <> "-" <> i(mega)
-    Enum.find_value(tmps, &write_tmp_dir(&1 <> subdir))
+    subdir = "#{sub}-#{mega}"
+    Enum.find_value(tmps, &write_tmp_dir(Path.join(&1, subdir)))
   end
 
   defp write_tmp_dir(path) do
@@ -111,9 +111,6 @@ defmodule Briefly.Entry do
   defp open(_prefix, tmp, attempts, _pid, _ets, _paths) do
     {:too_many_attempts, tmp, attempts}
   end
-
-  @compile {:inline, i: 1}
-  defp i(integer), do: Integer.to_string(integer)
 
   defp path(options, tmp) do
     time = :erlang.monotonic_time() |> to_string |> String.trim("-")

--- a/lib/briefly/entry.ex
+++ b/lib/briefly/entry.ex
@@ -18,9 +18,10 @@ defmodule Briefly.Entry do
 
   def init(_init_arg) do
     tmp = Briefly.Config.directory()
+    sub = Briefly.Config.sub_directory_prefix()
     cwd = Path.join(File.cwd!(), "tmp")
     ets = :ets.new(:briefly, [:private])
-    {:ok, {[tmp, cwd], ets}}
+    {:ok, {[tmp, cwd, sub], ets}}
   end
 
   def handle_call({:create, opts}, {caller_pid, _ref}, {tmps, ets} = state) do
@@ -68,7 +69,8 @@ defmodule Briefly.Entry do
 
   defp ensure_tmp_dir(tmps) do
     {mega, _, _} = :os.timestamp()
-    subdir = "briefly-" <> i(mega)
+    [_tmp, _cwd, sub] = tmps
+    subdir = sub <> "-" <> i(mega)
     Enum.find_value(tmps, &write_tmp_dir(&1 <> subdir))
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,7 @@ defmodule Briefly.Mixfile do
   defp default_env do
     [
       directory: [{:system, "TMPDIR"}, {:system, "TMP"}, {:system, "TEMP"}, "/tmp"],
+      sub_directory_prefix: "briefly",
       default_prefix: "briefly",
       default_extname: ""
     ]


### PR DESCRIPTION
Added the possibility to configure temporary sub directory name. (defaults to "briefly")

```elixir
config :briefly,
  directory: [{:system, "TMPDIR"}, {:system, "TMP"}, {:system, "TEMP"}, "/tmp"],
  sub_directory_prefix: "briefly",
  default_prefix: "briefly",
  default_extname: ""
```