### PR TITLE
Replace use Mix.Config with import Config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this


### PR DESCRIPTION
```
warning: use Mix.Config is deprecated. Use the Config module instead
  config/config.exs:3
```