### PR TITLE
Mark callback implemented methods as `@impl true`

### DIFF
--- a/lib/briefly.ex
+++ b/lib/briefly.ex
@@ -4,6 +4,7 @@ defmodule Briefly do
   use Application
 
   @doc false
+  @impl true
   def start(_type, _args) do
     Briefly.Supervisor.start_link()
   end

--- a/lib/briefly/entry.ex
+++ b/lib/briefly/entry.ex
@@ -16,6 +16,7 @@ defmodule Briefly.Entry do
 
   @max_attempts 10
 
+  @impl true
   def init(_init_arg) do
     tmp = Briefly.Config.directory()
     cwd = Path.join(File.cwd!(), "tmp")
@@ -23,6 +24,7 @@ defmodule Briefly.Entry do
     {:ok, {[tmp, cwd], ets}}
   end
 
+  @impl true
   def handle_call({:create, opts}, {caller_pid, _ref}, {tmps, ets} = state) do
     options = opts |> Enum.into(%{})
     pid = monitor_pid(options, caller_pid)
@@ -41,6 +43,7 @@ defmodule Briefly.Entry do
     {:reply, paths, state}
   end
 
+  @impl true
   def handle_info({:DOWN, _ref, :process, pid, _reason}, {_, ets} = state) do
     cleanup(ets, pid)
     {:noreply, state}

--- a/lib/briefly/supervisor.ex
+++ b/lib/briefly/supervisor.ex
@@ -1,10 +1,13 @@
 defmodule Briefly.Supervisor do
   @moduledoc false
 
+  use Supervisor
+
   def start_link() do
     Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
+  @impl true
   def init(:ok) do
     children = [
       Briefly.Entry


### PR DESCRIPTION
Marks the implemented methods as `@impl true`.

Makes `Briefly.Supervisor` use the `Supervisor` module.