### PR TITLE
Use `Path.join/1` when constructing tmp path to build

### DIFF
--- a/lib/briefly/entry.ex
+++ b/lib/briefly/entry.ex
@@ -72,7 +72,7 @@ defmodule Briefly.Entry do
   defp ensure_tmp_dir(tmps) do
     {mega, _, _} = :os.timestamp()
     subdir = "briefly-" <> i(mega)
-    Enum.find_value(tmps, &write_tmp_dir(&1 <> subdir))
+    Enum.find_value(tmps, &write_tmp_dir(Path.join([&1, subdir])))
   end
 
   defp write_tmp_dir(path) do


### PR DESCRIPTION
With the latest release, I found that briefly was creating the tmp directory in my current working directory as

```
/home/warmwaffles/src/github.com/warmwaffles/myapp/tmpbriefly-1673/briefly-576460745460590996-DLpRORtcCzq5gkApa5a
```

With this fix, it correctly builds the path using `Path.join` which can handle a trailing slash or missing trailing slash when joining paths.

Fix looks like

```
/tmp/briefly-1673/briefly-576460745460590996-DLpRORtcCzq5gkApa5a
```