### PR TITLE
Various updates from Plug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## v0.5.0
+
+- Add `Briefly.give_away/3` to transfer ownership of a tmp file.
+- Deprecate the `:monitor_pid` option.
+
+If you were previously using `:monitor_pid` like this:
+
+```elixir
+{:ok, path} = Briefly.create(monitor_pid: pid)
+```
+
+...then change it to this:
+
+```elixir
+{:ok, path} = Briefly.create()
+:ok = Briefly.give_away(path, pid)
+```
+
 ## v0.4.1 (2023-01-11)
 
 - Fix an issue with custom tmp dirs without a trailing slash ([#24](https://github.com/CargoSense/briefly/pull/24)) @srgpqt

--- a/lib/briefly.ex
+++ b/lib/briefly.ex
@@ -53,7 +53,7 @@ defmodule Briefly do
   @doc """
   Removes the temporary files and directories created by the process and returns their paths.
   """
-  @spec cleanup(pid()) :: [binary]
+  @spec cleanup(pid) :: [binary]
   def cleanup(pid \\ self()) do
     Briefly.Entry.cleanup(pid)
   end

--- a/lib/briefly.ex
+++ b/lib/briefly.ex
@@ -28,7 +28,9 @@ defmodule Briefly do
           | {:too_many_attempts, binary, pos_integer}
           | {:no_tmp, [binary]}
   def create(opts \\ []) do
-    GenServer.call(Briefly.Entry.server(), {:create, opts})
+    opts
+    |> Enum.into(%{})
+    |> Briefly.Entry.create()
   end
 
   @doc """
@@ -54,9 +56,9 @@ defmodule Briefly do
   return their paths.
   """
   @spec cleanup(pid() | nil) :: [binary]
-  def cleanup, do: cleanup(self())
+  def cleanup, do: Briefly.Entry.cleanup(self())
 
   def cleanup(monitor_pid) do
-    GenServer.call(Briefly.Entry.server(), {:cleanup, monitor_pid})
+    Briefly.Entry.cleanup(monitor_pid)
   end
 end

--- a/lib/briefly.ex
+++ b/lib/briefly.ex
@@ -16,8 +16,7 @@ defmodule Briefly do
   @type create_opts :: [
           {:prefix, binary},
           {:extname, binary},
-          {:directory, boolean},
-          {:monitor_pid, pid()}
+          {:directory, boolean}
         ]
 
   @doc """
@@ -60,5 +59,15 @@ defmodule Briefly do
 
   def cleanup(monitor_pid) do
     Briefly.Entry.cleanup(monitor_pid)
+  end
+
+  @doc """
+  Assign ownership of the given tmp file to another process.
+  """
+  @spec give_away(binary, pid, pid) :: :ok | {:error, binary}
+  def give_away(path, to_pid, from_pid \\ self())
+
+  def give_away(path, to_pid, from_pid) do
+    Briefly.Entry.give_away(path, to_pid, from_pid)
   end
 end

--- a/lib/briefly.ex
+++ b/lib/briefly.ex
@@ -51,20 +51,17 @@ defmodule Briefly do
   end
 
   @doc """
-  Removes the temporary files and directories created by the current process and
-  return their paths.
+  Removes the temporary files and directories created by the process and returns their paths.
   """
-  @spec cleanup(pid() | nil) :: [binary]
-  def cleanup, do: Briefly.Entry.cleanup(self())
-
-  def cleanup(monitor_pid) do
-    Briefly.Entry.cleanup(monitor_pid)
+  @spec cleanup(pid()) :: [binary]
+  def cleanup(pid \\ self()) do
+    Briefly.Entry.cleanup(pid)
   end
 
   @doc """
   Assign ownership of the given tmp file to another process.
   """
-  @spec give_away(binary, pid, pid) :: :ok | {:error, binary}
+  @spec give_away(binary, pid, pid) :: :ok | {:error, :unknown_path}
   def give_away(path, to_pid, from_pid \\ self())
 
   def give_away(path, to_pid, from_pid) do

--- a/lib/briefly/entry.ex
+++ b/lib/briefly/entry.ex
@@ -17,8 +17,18 @@ defmodule Briefly.Entry do
   end
 
   @doc false
+  # todo: remove deprecation warning on v0.6.0.
+  def create(%{monitor_pid: pid} = options) do
+    IO.warn("the :monitor_pid option is deprecated, please use Briefly.give_away/3 instead.")
+
+    with {:ok, path} <- create(Map.delete(options, :monitor_pid)) do
+      :ok = give_away(path, pid, self())
+      {:ok, path}
+    end
+  end
+
   def create(%{} = options) do
-    case find_tmp_dir(options) do
+    case ensure_tmp() do
       {:ok, tmp} ->
         open(options, tmp, 0)
 
@@ -43,6 +53,35 @@ defmodule Briefly.Entry do
     end
   end
 
+  @doc false
+  def give_away(path, to_pid, from_pid)
+      when is_binary(path) and is_pid(to_pid) and is_pid(from_pid) do
+    with [{^from_pid, _tmp}] <- :ets.lookup(@dir_table, from_pid),
+         true <- path_owner?(from_pid, path) do
+      case :ets.lookup(@dir_table, to_pid) do
+        [{^to_pid, _tmp}] ->
+          :ets.insert(@path_table, {to_pid, path})
+          :ets.delete_object(@path_table, {from_pid, path})
+
+          :ok
+
+        [] ->
+          server = server()
+
+          {:ok, tmps} = GenServer.call(server, :roots)
+          {:ok, tmp} = generate_tmp_dir(tmps)
+          :ok = GenServer.call(server, {:give_away, to_pid, tmp, path})
+
+          :ets.delete_object(@path_table, {from_pid, path})
+
+          :ok
+      end
+    else
+      _ ->
+        {:error, :unknown_path}
+    end
+  end
+
   ## Callbacks
   @impl true
   def init(_init_arg) do
@@ -58,6 +97,20 @@ defmodule Briefly.Entry do
   def handle_call({:monitor, pid}, _from, dirs) do
     Process.monitor(pid)
     {:reply, {:ok, dirs}, dirs}
+  end
+
+  def handle_call(:roots, _from, dirs) do
+    {:reply, {:ok, dirs}, dirs}
+  end
+
+  def handle_call({:give_away, pid, tmp, path}, _from, dirs) do
+    # Since we are writing on behalf of another process, we need to make sure
+    # the monitor and writing to the tables happen within the same operation.
+    Process.monitor(pid)
+    :ets.insert_new(@dir_table, {pid, tmp})
+    :ets.insert(@path_table, {pid, path})
+
+    {:reply, :ok, dirs}
   end
 
   @impl true
@@ -76,30 +129,33 @@ defmodule Briefly.Entry do
 
   ## Helpers
 
-  defp find_tmp_dir(_options) do
+  defp ensure_tmp() do
     pid = self()
-    server = server()
 
     case :ets.lookup(@dir_table, pid) do
       [{^pid, tmp}] ->
         {:ok, tmp}
 
       [] ->
+        server = server()
         {:ok, tmps} = GenServer.call(server, {:monitor, pid})
 
-        if tmp = ensure_tmp_dir(tmps) do
+        with {:ok, tmp} <- generate_tmp_dir(tmps) do
           true = :ets.insert_new(@dir_table, {pid, tmp})
           {:ok, tmp}
-        else
-          {:no_tmp, tmps}
         end
     end
   end
 
-  defp ensure_tmp_dir(tmps) do
+  defp generate_tmp_dir(tmp_roots) do
     {mega, _, _} = :os.timestamp()
     subdir = "briefly-#{mega}"
-    Enum.find_value(tmps, &write_tmp_dir(Path.join(&1, subdir)))
+
+    if tmp = Enum.find_value(tmp_roots, &write_tmp_dir(Path.join(&1, subdir))) do
+      {:ok, tmp}
+    else
+      {:no_tmp, tmp_roots}
+    end
   end
 
   defp write_tmp_dir(path) do
@@ -168,8 +224,10 @@ defmodule Briefly.Entry do
   defp extname(%{extname: value}), do: value
   defp extname(_), do: Briefly.Config.default_extname()
 
-  defp monitor_pid(%{monitor_pid: pid}, _), do: pid
-  defp monitor_pid(_options, pid), do: pid
+  defp path_owner?(pid, path) do
+    owned_paths = :ets.lookup(@path_table, pid)
+    Enum.any?(owned_paths, fn {_pid, p} -> p == path end)
+  end
 
   defp delete_path({_pid, path}) do
     File.rm_rf(path)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Briefly.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/CargoSense/briefly"
-  @version "0.4.1"
+  @version "0.5.0"
 
   def project do
     [

--- a/test/lib/briefly_test.exs
+++ b/test/lib/briefly_test.exs
@@ -79,7 +79,7 @@ defmodule Test.Briefly do
 
         receive do
           :cleanup ->
-            Briefly.cleanup()
+            assert [_] = Briefly.cleanup()
             send(parent, {:cleanup, path})
         end
 

--- a/test/lib/briefly_test.exs
+++ b/test/lib/briefly_test.exs
@@ -140,4 +140,10 @@ defmodule Test.Briefly do
         refute File.exists?(path)
     end
   end
+
+  test "terminate removes all files" do
+    {:ok, path} = Briefly.create()
+    :ok = Briefly.Entry.terminate(:shutdown, [])
+    refute File.exists?(path)
+  end
 end

--- a/test/lib/briefly_test.exs
+++ b/test/lib/briefly_test.exs
@@ -42,10 +42,12 @@ defmodule Test.Briefly do
 
     {pid, ref} =
       spawn_monitor(fn ->
-        {:ok, path} = Briefly.create(monitor_pid: monitor_pid)
-        send(parent, {:path, path})
-        File.write!(path, @fixture)
-        assert File.read!(path) == @fixture
+        assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
+                 {:ok, path} = Briefly.create(monitor_pid: monitor_pid)
+                 send(parent, {:path, path})
+                 File.write!(path, @fixture)
+                 assert File.read!(path) == @fixture
+               end) =~ "the :monitor_pid option is deprecated"
       end)
 
     path =
@@ -57,7 +59,7 @@ defmodule Test.Briefly do
 
     receive do
       {:DOWN, ^ref, :process, ^pid, :normal} ->
-        # {:ok, _} = Briefly.create()
+        {:ok, _} = Briefly.create()
         assert File.exists?(path)
 
         send(monitor_pid, :shutdown)
@@ -145,5 +147,151 @@ defmodule Test.Briefly do
     {:ok, path} = Briefly.create()
     :ok = Briefly.Entry.terminate(:shutdown, [])
     refute File.exists?(path)
+  end
+
+  describe "give_away/3" do
+    test "assigns ownership to other pid" do
+      parent = self()
+
+      {other_pid, other_ref} =
+        spawn_monitor(fn ->
+          receive do
+            :exit -> nil
+          end
+        end)
+
+      {pid, ref} =
+        spawn_monitor(fn ->
+          {:ok, path1} = Briefly.create()
+          send(parent, {:path1, path1})
+          File.open!(path1)
+
+          {:ok, path2} = Briefly.create()
+          send(parent, {:path2, path2})
+          File.open!(path2)
+
+          {:ok, path3} = Briefly.create()
+          send(parent, {:path3, path3})
+          File.open!(path3)
+
+          :ok = Briefly.give_away(path1, other_pid)
+          :ok = Briefly.give_away(path2, other_pid)
+        end)
+
+      path1 =
+        receive do
+          {:path1, path} -> path
+        after
+          1_000 -> flunk("didn't get a path")
+        end
+
+      path2 =
+        receive do
+          {:path2, path} -> path
+        after
+          1_000 -> flunk("didn't get a path")
+        end
+
+      path3 =
+        receive do
+          {:path3, path} -> path
+        after
+          1_000 -> flunk("didn't get a path")
+        end
+
+      receive do
+        {:DOWN, ^ref, :process, ^pid, :normal} ->
+          {:ok, _} = Briefly.create()
+
+          assert File.exists?(path1)
+          assert File.exists?(path2)
+          refute File.exists?(path3)
+      end
+
+      send(other_pid, :exit)
+
+      receive do
+        {:DOWN, ^other_ref, :process, ^other_pid, :normal} ->
+          # force sync by creating file in unknown process
+          parent = self()
+
+          spawn(fn ->
+            {:ok, _} = Briefly.create()
+            send(parent, :continue)
+          end)
+
+          receive do
+            :continue -> :ok
+          end
+
+          refute File.exists?(path1)
+          refute File.exists?(path2)
+      end
+    end
+
+    test "assigns ownership to other pid which has existing paths" do
+      parent = self()
+
+      {other_pid, other_ref} =
+        spawn_monitor(fn ->
+          {:ok, path} = Briefly.create()
+          send(parent, {:recipient, path})
+
+          receive do
+            :exit -> nil
+          end
+        end)
+
+      path =
+        receive do
+          {:recipient, path} -> path
+        after
+          1_000 -> flunk("didn't get a path")
+        end
+
+      {pid, ref} =
+        spawn_monitor(fn ->
+          {:ok, path1} = Briefly.create()
+          send(parent, {:path1, path1})
+          File.open!(path1)
+
+          :ok = Briefly.give_away(path1, other_pid)
+        end)
+
+      path1 =
+        receive do
+          {:path1, path} -> path
+        after
+          1_000 -> flunk("didn't get a path")
+        end
+
+      receive do
+        {:DOWN, ^ref, :process, ^pid, :normal} ->
+          {:ok, _} = Briefly.create()
+
+          assert File.exists?(path)
+          assert File.exists?(path1)
+      end
+
+      send(other_pid, :exit)
+
+      receive do
+        {:DOWN, ^other_ref, :process, ^other_pid, :normal} ->
+          # force sync by creating file in unknown process
+          parent = self()
+
+          spawn(fn ->
+            {:ok, _} = Briefly.create()
+            send(parent, :continue)
+          end)
+
+          receive do
+            :continue -> :ok
+          end
+
+          refute File.exists?(path)
+          refute File.exists?(path1)
+      end
+    end
   end
 end


### PR DESCRIPTION

- Removes process bottleneck by moving most operations to the caller, closes #2 
- Adds `Briefly.give_away/3` to transfer ownership of a tmp file.
- Deprecates `:monitor_pid` in favor of `Briefly.give_away/3` // @scarfacedeb