### PR TITLE
Handle disk full errors

### DIFF
--- a/lib/briefly.ex
+++ b/lib/briefly.ex
@@ -24,6 +24,7 @@ defmodule Briefly do
   """
   @spec create(create_opts) ::
           {:ok, binary}
+          | {:no_space, binary}
           | {:too_many_attempts, binary, pos_integer}
           | {:no_tmp, [binary]}
   def create(opts \\ []) do

--- a/lib/briefly/entry.ex
+++ b/lib/briefly/entry.ex
@@ -173,8 +173,14 @@ defmodule Briefly.Entry do
         :ets.insert(@path_table, {self(), path})
         {:ok, path}
 
+      {:error, :enospc} ->
+        {:no_space, path}
+
       {:error, reason} when reason in [:eexist, :eacces] ->
         open(options, tmp, attempts + 1)
+
+      error ->
+        error
     end
   end
 
@@ -186,8 +192,14 @@ defmodule Briefly.Entry do
         :ets.insert(@path_table, {self(), path})
         {:ok, path}
 
+      {:error, :enospc} ->
+        {:no_space, path}
+
       {:error, reason} when reason in [:eexist, :eacces] ->
         open(options, tmp, attempts + 1)
+
+      error ->
+        error
     end
   end
 


### PR DESCRIPTION
Handle the case that attempting to write to a disk gets back :enospc, indicating the disk is full. Also provide a general error handler so that if there are any other possible errors they return their failure reason, rather than causing the app to crash.

Resolves https://github.com/CargoSense/briefly/issues/39