### PR TITLE
Two Security Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ following Mix config:
 # config/config.exs
 config :briefly,
   directory: [{:system, "TMPDIR"}, {:system, "TMP"}, {:system, "TEMP"}, "/tmp"],
+  directory_mode: 0o755,
   default_prefix: "briefly",
   default_extname: ""
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Briefly can also create a temporary directory:
 
 
 ```elixir
-{:ok, dir} = Briefly.create(directory: true)
+{:ok, dir} = Briefly.create(type: :directory)
 File.write!(Path.join(dir, "test.txt"), "Some Text")
 # When this process exits, the directory and file are removed
 ```

--- a/guides/usage.livemd
+++ b/guides/usage.livemd
@@ -28,7 +28,7 @@ When this process exits, the file at `path` is removed.
 Briefly can also create a temporary directory:
 
 ```elixir
-{:ok, dir} = Briefly.create(directory: true)
+{:ok, dir} = Briefly.create(type: :directory)
 ```
 
 You can use [`File.stat/1`](https://hexdocs.pm/elixir/File.html#stat/1) to check the type:

--- a/lib/briefly.ex
+++ b/lib/briefly.ex
@@ -16,13 +16,17 @@ defmodule Briefly do
   @type create_opts :: [
           {:prefix, binary},
           {:extname, binary},
+          {:type, :path | :directory | :device},
           {:directory, boolean}
         ]
 
   @doc """
   Requests a temporary file to be created with the given options.
   """
-  @spec create(create_opts) :: {:ok, binary} | {:error, Exception.t()}
+  @spec create(create_opts) ::
+          {:ok, binary}
+          | {:ok, binary, pid}
+          | {:error, Exception.t()}
   def create(opts \\ []) do
     opts
     |> Enum.into(%{})

--- a/lib/briefly/config.ex
+++ b/lib/briefly/config.ex
@@ -3,6 +3,8 @@ defmodule Briefly.Config do
 
   def directory, do: get(:directory)
 
+  def directory_mode, do: get(:directory_mode)
+
   def default_prefix, do: get(:default_prefix)
 
   def default_extname, do: get(:default_extname)

--- a/lib/briefly/entry.ex
+++ b/lib/briefly/entry.ex
@@ -41,13 +41,34 @@ defmodule Briefly.Entry do
   @doc false
   def cleanup(pid) do
     case :ets.lookup(@dir_table, pid) do
-      [{^pid, _tmp}] ->
+      [{^pid, tmp}] ->
+        path_entries = :ets.lookup(@path_table, pid)
+
+        secondaries =
+          Enum.reduce(
+            path_entries,
+            MapSet.new(),
+            fn path_entry = {_pid, path_value}, seen ->
+              delete_path(path_entry)
+              if path_value.original_owner != pid do
+                MapSet.put(seen, %{path_value | path: nil})
+              else
+                seen
+              end
+            end
+          )
+
+        File.rmdir(tmp)
+
+        Enum.each(secondaries, fn %{original_owner: owner_pid, root_dir: dir} ->
+          if !pid_registered?(owner_pid) do
+            File.rmdir(dir)
+          end
+        end)
+
+        :ets.delete(@path_table, pid)
         :ets.delete(@dir_table, pid)
-
-        entries = :ets.lookup(@path_table, pid)
-        Enum.each(entries, &delete_path/1)
-
-        for {_pid, path} <- entries, do: path
+        for {_pid, path} <- path_entries, do: path
 
       [] ->
         []
@@ -58,19 +79,19 @@ defmodule Briefly.Entry do
   def give_away(path, to_pid, from_pid)
       when is_binary(path) and is_pid(to_pid) and is_pid(from_pid) do
     with true <- pid_registered?(from_pid),
-         true <- path_owner?(from_pid, path) do
+         path_entry when not is_nil(path_entry) <- path_entry_if_owner(from_pid, path) do
       if pid_registered?(to_pid) do
-        :ets.insert(@path_table, {to_pid, path})
-        :ets.delete_object(@path_table, {from_pid, path})
+        :ets.insert(@path_table, {to_pid, path_entry})
+        :ets.delete_object(@path_table, {from_pid, path_entry})
         :ok
       else
         server = server()
 
         {:ok, tmps} = GenServer.call(server, :roots)
         {:ok, tmp} = generate_tmp_dir(tmps)
-        :ok = GenServer.call(server, {:give_away, to_pid, tmp, path})
+        :ok = GenServer.call(server, {:give_away, to_pid, tmp, path_entry})
 
-        :ets.delete_object(@path_table, {from_pid, path})
+        :ets.delete_object(@path_table, {from_pid, path_entry})
 
         :ok
       end
@@ -101,12 +122,12 @@ defmodule Briefly.Entry do
     {:reply, {:ok, dirs}, dirs}
   end
 
-  def handle_call({:give_away, pid, tmp, path}, _from, dirs) do
+  def handle_call({:give_away, pid, tmp, path_entry}, _from, dirs) do
     # Since we are writing on behalf of another process, we need to make sure
     # the monitor and writing to the tables happen within the same operation.
     Process.monitor(pid)
     :ets.insert_new(@dir_table, {pid, tmp})
-    :ets.insert(@path_table, {pid, path})
+    :ets.insert(@path_table, {pid, path_entry})
 
     {:reply, :ok, dirs}
   end
@@ -123,6 +144,17 @@ defmodule Briefly.Entry do
   def terminate(_reason, _state) do
     folder = fn entry, :ok -> delete_path(entry) end
     :ets.foldl(folder, :ok, @path_table)
+
+    dir_folder = fn {_key, dir}, :ok ->
+      case File.rmdir(dir) do
+        :ok -> :ok
+        {:error, :eexist} -> :ok
+        {:error, :enoent} -> :ok
+        {:error, :enotdir} -> :ok
+      end
+    end
+
+    :ets.foldl(dir_folder, :ok, @dir_table)
   end
 
   ## Helpers
@@ -146,20 +178,33 @@ defmodule Briefly.Entry do
   end
 
   defp generate_tmp_dir(tmp_roots) do
-    {mega, _, _} = :os.timestamp()
-    subdir = "briefly-#{mega}"
+    subdir = path(%{prefix: "briefly-", extname: ""})
 
-    if tmp = Enum.find_value(tmp_roots, &write_tmp_dir(Path.join(&1, subdir))) do
+    if tmp = Enum.find_value(tmp_roots, &write_tmp_dir({&1, subdir})) do
       {:ok, tmp}
     else
       {:error, %Briefly.NoRootDirectoryError{tmp_dirs: tmp_roots}}
     end
   end
 
-  defp write_tmp_dir(path) do
-    case File.mkdir_p(path) do
-      :ok -> path
-      {:error, _} -> nil
+  defp write_tmp_dir({root, path}) do
+    fullpath = Path.join(root, path)
+
+    case File.mkdir_p(root) do
+      {:error, _} ->
+        nil
+
+      :ok ->
+        case File.mkdir(fullpath) do
+          {:error, _} ->
+            nil
+
+          :ok ->
+            case File.chmod(fullpath, Briefly.Config.directory_mode()) do
+              {:error, _} -> nil
+              :ok -> fullpath
+            end
+        end
     end
   end
 
@@ -168,7 +213,8 @@ defmodule Briefly.Entry do
 
     case File.mkdir_p(path) do
       :ok ->
-        :ets.insert(@path_table, {self(), path})
+        value = %{path: path, root_dir: tmp, original_owner: self()}
+        :ets.insert(@path_table, {self(), value})
         {:ok, path}
 
       {:error, reason} when reason in [:eexist, :eacces] ->
@@ -185,7 +231,8 @@ defmodule Briefly.Entry do
 
     case File.open(path, [:read, :write, :exclusive]) do
       {:ok, device_pid} ->
-        :ets.insert(@path_table, {self(), path})
+        value = %{path: path, root_dir: tmp, original_owner: self()}
+        :ets.insert(@path_table, {self(), value})
         {:ok, path, device_pid}
 
       {:error, reason} when reason in [:eexist, :eacces] ->
@@ -207,7 +254,8 @@ defmodule Briefly.Entry do
 
     case :file.write_file(path, "", [:write, :raw, :exclusive, :binary]) do
       :ok ->
-        :ets.insert(@path_table, {self(), path})
+        value = %{path: path, root_dir: tmp, original_owner: self()}
+        :ets.insert(@path_table, {self(), value})
         {:ok, path}
 
       {:error, reason} when reason in [:eexist, :eacces] ->
@@ -223,20 +271,21 @@ defmodule Briefly.Entry do
     {:error, last_error}
   end
 
-  defp path(options, tmp) do
+  defp path(options) do
     time = :erlang.monotonic_time() |> to_string |> String.trim("-")
 
-    folder =
-      Enum.join(
-        [
-          prefix(options),
-          time,
-          random_padding()
-        ],
-        "-"
-      ) <> extname(options)
+    Enum.join(
+      [
+        prefix(options),
+        time,
+        random_padding()
+      ],
+      "-"
+    ) <> extname(options)
+  end
 
-    Path.join([tmp, folder])
+  defp path(options, tmp) do
+    Path.join([tmp, path(options)])
   end
 
   defp random_padding(length \\ 20) do
@@ -256,12 +305,15 @@ defmodule Briefly.Entry do
     :ets.member(@dir_table, pid)
   end
 
-  defp path_owner?(pid, path) do
+  defp path_entry_if_owner(pid, path) do
     owned_paths = :ets.lookup(@path_table, pid)
-    Enum.any?(owned_paths, fn {_pid, p} -> p == path end)
+
+    Enum.find_value(owned_paths, fn {_pid, %{path: p} = entry} ->
+      if p == path, do: entry
+    end)
   end
 
-  defp delete_path({_pid, path}) do
+  defp delete_path({_pid, %{path: path}}) do
     File.rm_rf(path)
     :ok
   end

--- a/mix.exs
+++ b/mix.exs
@@ -56,6 +56,7 @@ defmodule Briefly.Mixfile do
   defp default_env do
     [
       directory: [{:system, "TMPDIR"}, {:system, "TMP"}, {:system, "TEMP"}, "/tmp"],
+      directory_mode: 0o755,
       default_prefix: "briefly",
       default_extname: ""
     ]

--- a/test/lib/briefly_test.exs
+++ b/test/lib/briefly_test.exs
@@ -117,12 +117,38 @@ defmodule Test.Briefly do
       end)
   end
 
-  test "can create and remove a directory" do
+  test "can create and remove a directory with the deprecated boolean option" do
     parent = self()
 
     {pid, ref} =
       spawn_monitor(fn ->
         {:ok, path} = Briefly.create(directory: true)
+        send(parent, {:path, path})
+        assert File.stat!(path).type == :directory
+        File.write!(Path.join(path, "a-file"), "some content")
+      end)
+
+    path =
+      receive do
+        {:path, path} -> path
+      after
+        1_000 -> flunk("didn't get a path")
+      end
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, :normal} ->
+        # Give the rm_rf a chance to finish
+        :timer.sleep(1000)
+        refute File.exists?(path)
+    end
+  end
+
+  test "can create and remove a directory with the type: :directory option" do
+    parent = self()
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        {:ok, path} = Briefly.create(type: :directory)
         send(parent, {:path, path})
         assert File.stat!(path).type == :directory
         File.write!(Path.join(path, "a-file"), "some content")
@@ -292,6 +318,41 @@ defmodule Test.Briefly do
           refute File.exists?(path)
           refute File.exists?(path1)
       end
+    end
+  end
+
+  test "returns an io device if device is requested" do
+    parent = self()
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        {:ok, path1, device1} = Briefly.create(%{type: :device})
+        IO.write(device1, @fixture)
+        assert File.read!(path1) == @fixture
+        {:ok, path2, device2} = Briefly.create(%{type: :device})
+        File.write!(path2, @fixture)
+        assert IO.read(device2, 1024) == @fixture
+        send(parent, {:paths_and_devices, [path1, path2], [device1, device2]})
+      end)
+
+    {paths, devices} =
+      receive do
+        {:paths_and_devices, paths, devices} -> {paths, devices}
+      after
+        1_000 -> flunk("didn't get paths")
+      end
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, :normal} ->
+        {:ok, _} = Briefly.create()
+
+        Enum.each(paths, fn path ->
+          refute File.exists?(path)
+        end)
+
+        Enum.each(devices, fn device ->
+          refute Process.info(device)
+        end)
     end
   end
 end


### PR DESCRIPTION
First, allow a user to receive an io_device for the newly opened file. This mirrors the behavior of mkstemp in standard libraries.

Second, when creating the base temporary directories, ensure that the directory is newly created. We could do this once in the server, but I did it new for each pid.
Cleanup these temporary directories on pid shutdown.

Includes tests for both features. 